### PR TITLE
Update module for Terraform 0.12

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 pipeline:
   validate:
-    image: quay.io/ukhomeofficedigital/terraform-toolset:v0.2.5
+    image: quay.io/ukhomeofficedigital/terraform-toolset:v0.12.6
     commands:
     - /acp/scripts/tf-validate.sh --no-docs
     when:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 data "aws_iam_policy_document" "assume_role" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
   statement {
     effect = "Allow"
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 data "aws_iam_policy_document" "lambda_basic" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
   statement {
     sid = "AllowWriteToCloudwatchLogs"
@@ -32,9 +32,9 @@ data "aws_iam_policy_document" "lambda_basic" {
 }
 
 data "aws_iam_policy_document" "lambda" {
-  count = "${(var.create_with_kms_key == 1 ? 1 : 0) * var.create}"
+  count = var.create_with_kms_key && var.create ? 1 : 0
 
-  source_json = "${data.aws_iam_policy_document.lambda_basic.0.json}"
+  source_json = data.aws_iam_policy_document.lambda_basic[0].json
 
   statement {
     sid = "AllowKMSDecrypt"
@@ -48,17 +48,25 @@ data "aws_iam_policy_document" "lambda" {
 }
 
 resource "aws_iam_role" "lambda" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
   name_prefix        = "lambda"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.0.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
 }
 
 resource "aws_iam_role_policy" "lambda" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
   name_prefix = "lambda-policy-"
-  role        = "${aws_iam_role.lambda.0.id}"
+  role        = aws_iam_role.lambda[0].id
 
-  policy = "${element(compact(concat(data.aws_iam_policy_document.lambda.*.json, data.aws_iam_policy_document.lambda_basic.*.json)), 0)}"
+  policy = element(
+    compact(
+      concat(
+        data.aws_iam_policy_document.lambda.*.json,
+        data.aws_iam_policy_document.lambda_basic.*.json,
+      ),
+    ),
+    0,
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -1,154 +1,167 @@
+terraform {
+  required_version = ">= 0.12"
+}
+
 data "aws_sns_topic" "topic" {
-  count = "${(1 - var.create_sns_topic) * var.create}"
-  name  = "${var.sns_topic_name}"
+  count = var.create_sns_topic && var.create ? 1 : 0
+  name  = var.sns_topic_name
 }
 
 resource "aws_sns_topic" "topic" {
-  count = "${var.create_sns_topic * var.create}"
+  count = var.create_sns_topic && var.create ? 1 : 0
 
-  name = "${var.sns_topic_name}"
+  name = var.sns_topic_name
 }
 
 locals {
-  sns_topic_arn = "${element(concat(aws_sns_topic.topic.*.arn, data.aws_sns_topic.topic.*.arn, list("")), 0)}"
+  sns_topic_arn = element(
+    concat(
+      aws_sns_topic.topic.*.arn,
+      data.aws_sns_topic.topic.*.arn,
+      [""],
+    ),
+    0,
+  )
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
-  topic_arn = "${local.sns_topic_arn}"
+  topic_arn = local.sns_topic_arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack.0.function_name}"
+  function_name = aws_lambda_function.notify_slack[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${local.sns_topic_arn}"
+  source_arn    = local.sns_topic_arn
 }
 
 data "null_data_source" "lambda_file" {
-  inputs {
-    filename = "${substr("${path.module}/functions/notify_slack.py", length(path.cwd) + 1, -1)}"
+  inputs = {
+    filename = "${path.module}/functions/notify_slack.py"
   }
 }
 
 #  the path the python or node.js file is stored in the directory
 data "null_data_source" "lambda_archive" {
-  inputs {
-    filename = "${substr("${path.module}/functions/notify_slack.zip", length(path.cwd) + 1, -1)}"
+  inputs = {
+    filename = "${path.module}/functions/notify_slack.zip"
   }
 }
 
 data "archive_file" "notify_slack" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
   type        = "zip"
-  source_file = "${data.null_data_source.lambda_file.outputs.filename}"
-  output_path = "${data.null_data_source.lambda_archive.outputs.filename}"
+  source_file = data.null_data_source.lambda_file.outputs.filename
+  output_path = data.null_data_source.lambda_archive.outputs.filename
 }
 
 resource "aws_lambda_function" "notify_slack" {
-  count = "${var.create}"
+  count = var.create ? 1 : 0
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
+
+  depends_on = [data.archive_file.notify_slack[0]]
 }
 
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.topic.arn}"
+  arn       = aws_sns_topic.topic[0].arn
 }
 
 ## eu-west-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.eu-west-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.eu-west-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_eu_west_1" {
-  count     = "${var.create}"
-  provider  = "aws.eu-west-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.eu-west-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_eu_west_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_eu_west_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_eu_west_1" {
-  count    = "${var.create}"
-  provider = "aws.eu-west-1"
+  count    = var.create ? 1 : 0
+  provider = aws.eu-west-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_eu_west_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_eu_west_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_eu_west_1" {
-  count    = "${var.create}"
-  provider = "aws.eu-west-1"
+  count    = var.create ? 1 : 0
+  provider = aws.eu-west-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -156,72 +169,72 @@ resource "aws_lambda_function" "notify_slack_eu_west_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_eu_west_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.eu-west-1"
+  provider    = aws.eu-west-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_eu_west_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_eu_west_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_eu_west_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack.arn}"
-  provider  = "aws.eu-west-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack[0].arn
+  provider  = aws.eu-west-1
 }
 
 ## us-east-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_us_east_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.us-east-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.us-east-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_us_east_1" {
-  count     = "${var.create}"
-  provider  = "aws.us-east-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_us_east_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.us-east-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_us_east_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_us_east_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_us_east_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_us_east_1" {
-  count    = "${var.create}"
-  provider = "aws.us-east-1"
+  count    = var.create ? 1 : 0
+  provider = aws.us-east-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_eu_west_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_eu_west_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_us_east_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_us_east_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_us_east_1" {
-  count    = "${var.create}"
-  provider = "aws.us-east-1"
+  count    = var.create ? 1 : 0
+  provider = aws.us-east-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -229,72 +242,72 @@ resource "aws_lambda_function" "notify_slack_us_east_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_us_east_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.us-east-1"
+  provider    = aws.us-east-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_us_east_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_west_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_west_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_us_east_1.arn}"
-  provider  = "aws.us-east-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_us_east_1[0].arn
+  provider  = aws.us-east-1
 }
 
 ## us-east-2
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_us_east_2" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.us-east-2"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.us-east-2
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_us_east_2" {
-  count     = "${var.create}"
-  provider  = "aws.us-east-2"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_us_east_2.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.us-east-2
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_us_east_2[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_us_east_2.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_us_east_2[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_us_east_2" {
-  count    = "${var.create}"
-  provider = "aws.us-east-2"
+  count    = var.create ? 1 : 0
+  provider = aws.us-east-2
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_us_east_2.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_us_east_2[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_us_east_2.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_us_east_2[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_us_east_2" {
-  count    = "${var.create}"
-  provider = "aws.us-east-2"
+  count    = var.create ? 1 : 0
+  provider = aws.us-east-2
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -302,72 +315,72 @@ resource "aws_lambda_function" "notify_slack_us_east_2" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_us_east_2" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.us-east-2"
+  provider    = aws.us-east-2
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_us_east_2" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_east_2.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_east_2.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_us_east_2.arn}"
-  provider  = "aws.us-east-2"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_us_east_2[0].arn
+  provider  = aws.us-east-2
 }
 
 ## us-west-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_us_west_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.us-west-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.us-west-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_us_west_1" {
-  count     = "${var.create}"
-  provider  = "aws.us-west-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_us_west_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.us-west-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_us_west_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_us_west_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_us_west_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_us_west_1" {
-  count    = "${var.create}"
-  provider = "aws.us-west-1"
+  count    = var.create ? 1 : 0
+  provider = aws.us-west-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_us_west_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_us_west_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_us_west_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_us_west_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_us_west_1" {
-  count    = "${var.create}"
-  provider = "aws.us-west-1"
+  count    = var.create ? 1 : 0
+  provider = aws.us-west-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -375,72 +388,72 @@ resource "aws_lambda_function" "notify_slack_us_west_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_us_west_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.us-west-1"
+  provider    = aws.us-west-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_us_west_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_west_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_west_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_us_west_1.arn}"
-  provider  = "aws.us-west-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_us_west_1[0].arn
+  provider  = aws.us-west-1
 }
 
 ## us-west-2
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_us_west_2" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.us-west-2"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.us-west-2
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_us_west_2" {
-  count     = "${var.create}"
-  provider  = "aws.us-west-2"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_us_west_2.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.us-west-2
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_us_west_2[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_us_west_2.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_us_west_2[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_us_west_2" {
-  count    = "${var.create}"
-  provider = "aws.us-west-2"
+  count    = var.create ? 1 : 0
+  provider = aws.us-west-2
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_us_west_2.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_us_west_2[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_us_west_2.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_us_west_2[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_us_west_2" {
-  count    = "${var.create}"
-  provider = "aws.us-west-2"
+  count    = var.create ? 1 : 0
+  provider = aws.us-west-2
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -448,72 +461,72 @@ resource "aws_lambda_function" "notify_slack_us_west_2" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_us_west_2" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.us-west-2"
+  provider    = aws.us-west-2
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_us_west_2" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_west_2.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_us_west_2.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_us_west_2.arn}"
-  provider  = "aws.us-west-2"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_us_west_2[0].arn
+  provider  = aws.us-west-2
 }
 
 ## ap-southeast-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_ap_southeast_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.ap-southeast-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.ap-southeast-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_ap_southeast_1" {
-  count     = "${var.create}"
-  provider  = "aws.ap-southeast-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.ap-southeast-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_ap_southeast_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_ap_southeast_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_ap_southeast_1" {
-  count    = "${var.create}"
-  provider = "aws.ap-southeast-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-southeast-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_ap_southeast_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_ap_southeast_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_ap_southeast_1" {
-  count    = "${var.create}"
-  provider = "aws.ap-southeast-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-southeast-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -521,72 +534,72 @@ resource "aws_lambda_function" "notify_slack_ap_southeast_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_ap_southeast_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.ap-southeast-1"
+  provider    = aws.ap-southeast-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_ap_southeast_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_southeast_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_southeast_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_1.arn}"
-  provider  = "aws.ap-southeast-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_1[0].arn
+  provider  = aws.ap-southeast-1
 }
 
 ## ap-southeast-2
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_ap_southeast_2" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.ap-southeast-2"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.ap-southeast-2
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_ap_southeast_2" {
-  count     = "${var.create}"
-  provider  = "aws.ap-southeast-2"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_2.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.ap-southeast-2
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_2[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_ap_southeast_2.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_ap_southeast_2[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_ap_southeast_2" {
-  count    = "${var.create}"
-  provider = "aws.ap-southeast-2"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-southeast-2
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_ap_southeast_2.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_ap_southeast_2[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_2.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_2[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_ap_southeast_2" {
-  count    = "${var.create}"
-  provider = "aws.ap-southeast-2"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-southeast-2
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -594,72 +607,72 @@ resource "aws_lambda_function" "notify_slack_ap_southeast_2" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_ap_southeast_2" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.ap-southeast-2"
+  provider    = aws.ap-southeast-2
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_ap_southeast_2" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_southeast_2.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_southeast_2.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_2.arn}"
-  provider  = "aws.ap-southeast-2"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_ap_southeast_2[0].arn
+  provider  = aws.ap-southeast-2
 }
 
 ## ap-northeast-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_ap_northeast_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.ap-northeast-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.ap-northeast-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_ap_northeast_1" {
-  count     = "${var.create}"
-  provider  = "aws.ap-northeast-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.ap-northeast-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_ap_northeast_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_ap_northeast_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_ap_northeast_1" {
-  count    = "${var.create}"
-  provider = "aws.ap-northeast-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-northeast-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_ap_northeast_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_ap_northeast_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_ap_northeast_1" {
-  count    = "${var.create}"
-  provider = "aws.ap-northeast-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-northeast-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -667,72 +680,72 @@ resource "aws_lambda_function" "notify_slack_ap_northeast_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_ap_northeast_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.ap-northeast-1"
+  provider    = aws.ap-northeast-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_ap_northeast_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_northeast_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_northeast_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_1.arn}"
-  provider  = "aws.ap-northeast-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_1[0].arn
+  provider  = aws.ap-northeast-1
 }
 
 ## ap-northeast-2
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_ap_northeast_2" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.ap-northeast-2"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.ap-northeast-2
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_ap_northeast_2" {
-  count     = "${var.create}"
-  provider  = "aws.ap-northeast-2"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_2.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.ap-northeast-2
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_2[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_ap_northeast_2.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_ap_northeast_2[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_ap_northeast_2" {
-  count    = "${var.create}"
-  provider = "aws.ap-northeast-2"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-northeast-2
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_ap_northeast_2.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_ap_northeast_2[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_2.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_2[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_ap_northeast_2" {
-  count    = "${var.create}"
-  provider = "aws.ap-northeast-2"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-northeast-2
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -740,72 +753,72 @@ resource "aws_lambda_function" "notify_slack_ap_northeast_2" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_ap_northeast_2" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.ap-northeast-2"
+  provider    = aws.ap-northeast-2
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_ap_northeast_2" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_northeast_2.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_northeast_2.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_2.arn}"
-  provider  = "aws.ap-northeast-2"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_ap_northeast_2[0].arn
+  provider  = aws.ap-northeast-2
 }
 
 ## ap-south-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_ap_south_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.ap-south-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.ap-south-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_ap_south_1" {
-  count     = "${var.create}"
-  provider  = "aws.ap-south-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_ap_south_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.ap-south-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_ap_south_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_ap_south_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_ap_south_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_ap_south_1" {
-  count    = "${var.create}"
-  provider = "aws.ap-south-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-south-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_ap_south_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_ap_south_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_ap_south_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_ap_south_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_ap_south_1" {
-  count    = "${var.create}"
-  provider = "aws.ap-south-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ap-south-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -813,72 +826,72 @@ resource "aws_lambda_function" "notify_slack_ap_south_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_ap_south_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.ap-south-1"
+  provider    = aws.ap-south-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_ap_south_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_south_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ap_south_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_ap_south_1.arn}"
-  provider  = "aws.ap-south-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_ap_south_1[0].arn
+  provider  = aws.ap-south-1
 }
 
 ## eu-central-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_eu_central_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.eu-central-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.eu-central-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_eu_central_1" {
-  count     = "${var.create}"
-  provider  = "aws.eu-central-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_eu_central_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.eu-central-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_eu_central_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_eu_central_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_eu_central_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_eu_central_1" {
-  count    = "${var.create}"
-  provider = "aws.eu-central-1"
+  count    = var.create ? 1 : 0
+  provider = aws.eu-central-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_eu_central_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_eu_central_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_eu_central_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_eu_central_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_eu_central_1" {
-  count    = "${var.create}"
-  provider = "aws.eu-central-1"
+  count    = var.create ? 1 : 0
+  provider = aws.eu-central-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -886,72 +899,72 @@ resource "aws_lambda_function" "notify_slack_eu_central_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_eu_central_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.eu-central-1"
+  provider    = aws.eu-central-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_eu_central_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_eu_central_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_eu_central_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_eu_central_1.arn}"
-  provider  = "aws.eu-central-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_eu_central_1[0].arn
+  provider  = aws.eu-central-1
 }
 
 ## eu-west-3
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_eu_west_3" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.eu-west-3"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.eu-west-3
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_eu_west_3" {
-  count     = "${var.create}"
-  provider  = "aws.eu-west-3"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_eu_west_3.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.eu-west-3
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_eu_west_3[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_eu_west_3.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_eu_west_3[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_eu_west_3" {
-  count    = "${var.create}"
-  provider = "aws.eu-west-3"
+  count    = var.create ? 1 : 0
+  provider = aws.eu-west-3
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_eu_west_3.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_eu_west_3[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_eu_west_3.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_eu_west_3[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_eu_west_3" {
-  count    = "${var.create}"
-  provider = "aws.eu-west-3"
+  count    = var.create ? 1 : 0
+  provider = aws.eu-west-3
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -959,72 +972,72 @@ resource "aws_lambda_function" "notify_slack_eu_west_3" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_eu_west_3" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.eu-west-3"
+  provider    = aws.eu-west-3
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_eu_west_3" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_eu_west_3.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_eu_west_3.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_eu_west_3.arn}"
-  provider  = "aws.eu-west-3"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_eu_west_3[0].arn
+  provider  = aws.eu-west-3
 }
 
 ## sa-east-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_sa_east_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.sa-east-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.sa-east-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_sa_east_1" {
-  count     = "${var.create}"
-  provider  = "aws.sa-east-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_sa_east_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.sa-east-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_sa_east_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_sa_east_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_sa_east_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_sa_east_1" {
-  count    = "${var.create}"
-  provider = "aws.sa-east-1"
+  count    = var.create ? 1 : 0
+  provider = aws.sa-east-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_sa_east_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_sa_east_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_sa_east_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_sa_east_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_sa_east_1" {
-  count    = "${var.create}"
-  provider = "aws.sa-east-1"
+  count    = var.create ? 1 : 0
+  provider = aws.sa-east-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -1032,72 +1045,72 @@ resource "aws_lambda_function" "notify_slack_sa_east_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_sa_east_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.sa-east-1"
+  provider    = aws.sa-east-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_sa_east_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_sa_east_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_sa_east_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_sa_east_1.arn}"
-  provider  = "aws.sa-east-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_sa_east_1[0].arn
+  provider  = aws.sa-east-1
 }
 
 ## ca-central-1
 
 resource "aws_sns_topic" "guard_duty_findings_to_slack_ca_central_1" {
-  count    = "${var.create_sns_topic * var.create}"
-  provider = "aws.ca-central-1"
-  name     = "${var.sns_topic_name}"
+  count    = var.create_sns_topic && var.create ? 1 : 0
+  provider = aws.ca-central-1
+  name     = var.sns_topic_name
 }
 
 resource "aws_sns_topic_subscription" "sns_notify_slack_ca_central_1" {
-  count     = "${var.create}"
-  provider  = "aws.ca-central-1"
-  topic_arn = "${aws_sns_topic.guard_duty_findings_to_slack_ca_central_1.arn}"
+  count     = var.create ? 1 : 0
+  provider  = aws.ca-central-1
+  topic_arn = aws_sns_topic.guard_duty_findings_to_slack_ca_central_1[0].arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.notify_slack_ca_central_1.0.arn}"
+  endpoint  = aws_lambda_function.notify_slack_ca_central_1[0].arn
 }
 
 resource "aws_lambda_permission" "sns_notify_slack_ca_central_1" {
-  count    = "${var.create}"
-  provider = "aws.ca-central-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ca-central-1
 
   statement_id  = "ExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.notify_slack_ca_central_1.0.function_name}"
+  function_name = aws_lambda_function.notify_slack_ca_central_1[0].function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = "${aws_sns_topic.guard_duty_findings_to_slack_ca_central_1.arn}"
+  source_arn    = aws_sns_topic.guard_duty_findings_to_slack_ca_central_1[0].arn
 }
 
 resource "aws_lambda_function" "notify_slack_ca_central_1" {
-  count    = "${var.create}"
-  provider = "aws.ca-central-1"
+  count    = var.create ? 1 : 0
+  provider = aws.ca-central-1
 
-  filename = "${data.archive_file.notify_slack.0.output_path}"
+  filename = data.archive_file.notify_slack[0].output_path
 
-  function_name = "${var.lambda_function_name}"
+  function_name = var.lambda_function_name
 
-  role             = "${aws_iam_role.lambda.arn}"
+  role             = aws_iam_role.lambda[0].arn
   handler          = "notify_slack.lambda_handler"
-  source_code_hash = "${data.archive_file.notify_slack.0.output_base64sha256}"
+  source_code_hash = data.archive_file.notify_slack[0].output_base64sha256
   runtime          = "python3.6"
   timeout          = 30
 
   environment {
     variables = {
-      SLACK_WEBHOOK_URL = "${var.slack_webhook_url}"
-      SLACK_CHANNEL     = "${var.slack_channel}"
-      SLACK_USERNAME    = "${var.slack_username}"
-      SLACK_EMOJI       = "${var.slack_emoji}"
+      SLACK_WEBHOOK_URL = var.slack_webhook_url
+      SLACK_CHANNEL     = var.slack_channel
+      SLACK_USERNAME    = var.slack_username
+      SLACK_EMOJI       = var.slack_emoji
     }
   }
 
   lifecycle {
     ignore_changes = [
-      "filename",
-      "last_modified",
+      filename,
+      last_modified,
     ]
   }
 }
@@ -1105,14 +1118,14 @@ resource "aws_lambda_function" "notify_slack_ca_central_1" {
 resource "aws_cloudwatch_event_rule" "guard_duty_findings_to_slack_ca_central_1" {
   name        = "guardduty-finding-events"
   description = "AWS GuardDuty event findings"
-  provider    = "aws.ca-central-1"
+  provider    = aws.ca-central-1
 
-  event_pattern = "${file("${path.module}/event-pattern.json")}"
+  event_pattern = file("${path.module}/event-pattern.json")
 }
 
 resource "aws_cloudwatch_event_target" "guard_duty_findings_to_slack_ca_central_1" {
-  rule      = "${aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ca_central_1.name}"
+  rule      = aws_cloudwatch_event_rule.guard_duty_findings_to_slack_ca_central_1.name
   target_id = "slack-topic"
-  arn       = "${aws_sns_topic.guard_duty_findings_to_slack_ca_central_1.arn}"
-  provider  = "aws.ca-central-1"
+  arn       = aws_sns_topic.guard_duty_findings_to_slack_ca_central_1[0].arn
+  provider  = aws.ca-central-1
 }

--- a/provider.tf
+++ b/provider.tf
@@ -71,3 +71,4 @@ provider "aws" {
   alias  = "ca-central-1"
   region = "ca-central-1"
 }
+

--- a/variable.tf
+++ b/variable.tf
@@ -43,3 +43,4 @@ variable "kms_key_arn" {
   description = "ARN of the KMS key used for decrypting slack webhook url"
   default     = ""
 }
+


### PR DESCRIPTION
Note: To update successfully, I had to temporarily remove `filename` from the ignored changes in each Lambda function, otherwise I got an error stating the the Lamdba archive file could not be found.

The problem seemed to be the filename in the state file being different to the filename after updating the module (possibly because the way `path.module` worked was changed in Terraform) - https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/21