### PR TITLE
ACPENG-3266: Removing docs check step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
   image: quay.io/ukhomeofficedigital/terraform-toolset:v1.1.3-2
   commands:
   - mv __providers__._tf_ providers.tf
-  - /acp/scripts/tf-validate.sh
+  - /acp/scripts/tf-validate.sh --no-docs
   - mv providers.tf __providers__._tf_
   when:
     event:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 providers.tf
 terraform.tfvars
 .terraform.lock.hcl
+__pycache__/


### PR DESCRIPTION
Initial Drone run failed due to validation of readme file. Added --nodocs flag to bypass, no impact on functionality.

Added __pycache__ to gitignore